### PR TITLE
Including a -k switch in Curl

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -323,7 +323,7 @@ KUBERNETES_PUBLIC_IP_ADDRESS=$(az network public-ip show -g kubernetes \
 Make a HTTP request for the Kubernetes version info:
 
 ```shell
-curl --cacert ca.pem https://$KUBERNETES_PUBLIC_IP_ADDRESS:6443/version
+curl --cacert ca.pem -k https://$KUBERNETES_PUBLIC_IP_ADDRESS:6443/version
 ```
 
 > output


### PR DESCRIPTION
I think you will need to include a "_-k_" switch in curl, that ignores an insecure connection? Without the -k, I was being thrown "_curl: (77) schannel: next InitializeSecurityContext failed: SEC_E_UNTRUSTED_ROOT (0x80090325) - The certificate chain was issued by an authority that is not trusted._". It's from the local machine I am on, using (_the new_) Windows Terminal. Including the -k, it seemed to have worked.

Point to note - It worked without any hassles from within a Controller machine (had to copy _ca.pem_ first), or a Worker machine.